### PR TITLE
Fix #11 GitHub provider only returns public emails

### DIFF
--- a/src/providers/github/users.js
+++ b/src/providers/github/users.js
@@ -51,7 +51,7 @@ async function getUser(token) {
                 method: 'GET',
                 headers,
           });
-          const emails: GithubEmail[] = await res.json()
+          const emails = await res.json()
           console.log('[provider user emails]', emails);
           data.emails = emails
           data.email = (emails.find((e) => e.primary) ?? emails[0]).email

--- a/src/providers/github/users.js
+++ b/src/providers/github/users.js
@@ -38,12 +38,24 @@ async function getUser(token) {
       'user-agent': 'cool-bio-analytics-github-oauth-login',
     };
     console.log('[user getUser headers]', headers);
-    const getUserResponse = await fetch('https://api.github.com/user', {
+      const getUserResponse = await fetch('https://api.github.com/user', {
       method: 'GET',
       headers,
     });
     const data = await getUserResponse.json();
     console.log('[provider user data]', data);
+    if (!data.email) {
+          // If the user does not have a public email, get another via the GitHub API
+          // See https://docs.github.com/en/rest/users/emails#list-public-email-addresses-for-the-authenticated-user
+          const res = await fetch("https://api.github.com/user/emails", {
+                method: 'GET',
+                headers,
+          });
+          const emails: GithubEmail[] = await res.json()
+          console.log('[provider user emails]', emails);
+          data.emails = emails
+          data.email = (emails.find((e) => e.primary) ?? emails[0]).email
+    }
     return data;
   } catch (e) {
     console.log('[get user error]', e);


### PR DESCRIPTION
If the user does not have a public email, get another via the GitHub API using the token with user:email scope